### PR TITLE
Fix infinite loop in DeltaCompressedReaderMapper.

### DIFF
--- a/src/graph_iterator.rs
+++ b/src/graph_iterator.rs
@@ -30,6 +30,10 @@ impl<R: Read, F: Fn()->R> EdgeMapper for DeltaCompressedReaderMapper<R, F> {
 
         let mut buffer = vec![0u8; 1 << 16];
         while let Ok(read) = reader.read(&mut buffer[..]) {
+            if read == 0 {
+                // Reached EOF.
+                break;
+            }
             for &byte in &buffer[..read] {
                 if byte == 0 && delta == 0 {
                     depth += 1;


### PR DESCRIPTION
The trait `std::io::Read`, (in the current Rust version at least - 1.6), defines `read` to return `Ok(0)` when "end of file" (EOF) has been reached. This causes the main loop in `DeltaCompressedReaderMapper::map_edges` to never terminate.

This pull request simply adds a check on the number of bytes read. If it is zero, we assume that EOF has been reached and we break out of the loop.

Minimal example:

```
echo -e "0 1\n1 2\n2 0" > mwe.txt
cargo build --release  # /!\ cannot use `cargo run` as it writes stuff to stdout
/target/release/COST parse_to_hilbert < mwe.txt > compressed.dat
cargo run --release stats compressed compressed.dat
```
