### PR TITLE
Fix edges overflow error in stats binary

### DIFF
--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -32,7 +32,7 @@ fn main() {
 fn stats<G: EdgeMapper>(graph: &G) -> u32 {
     let mut max_x = 0;
     let mut max_y = 0;
-    let mut edges = 0;
+    let mut edges = 0u64;
     graph.map_edges(|x, y| {
         if max_x < x { max_x = x; }
         if max_y < y { max_y = y; }


### PR DESCRIPTION
Hi,
I was trying to reproduce some of the graphs from your COST paper (amazing paper btw!) and I was using the stat binary to find the largest vertex identifier. I tried running the stats binary for the uk-2007-05 dataset and I noticed that it was reporting the edges to be negative, -556233648 to be precise, instead of the correct value of 3738733648.
On investigation, I found that the reason behind it was the fact that rust was automatically inferring the type of the edges variable to be a 32-bit signed integer, which has a max value of 2,147,483,647, thus resulting in overflow. Forcing the edges variable to be a 64-bit unsigned integer fixed the issue.

Another issue I noticed was that the iterators assume that the vertex labels are within the range of uint 32 (max value of ~4.2B) so the code will result in a lot of overflow errors if vertex labels are greater than that number. I have created a separate issue for that.